### PR TITLE
Add missing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,8 @@ requires-python = ">=3.11"
 dependencies = [
     "youtube-transcript-api>=0.6.1"
 ]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+youtube-transcript-api>=0.6.1
+
+# Development dependencies
+pytest>=7.0


### PR DESCRIPTION
## Summary
- add pytest as a development dependency in `pyproject.toml`
- provide a `requirements.txt` listing runtime and development dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'youtube_transcript_api')*

------
https://chatgpt.com/codex/tasks/task_e_686c27bfd6d4832da72dd104c44849c6